### PR TITLE
fix: update import to be compatible with python3

### DIFF
--- a/datadomain/__init__.py
+++ b/datadomain/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from datadomain.datadomain import DataDomain

--- a/datadomain/__init__.py
+++ b/datadomain/__init__.py
@@ -1,1 +1,1 @@
-from datadomain import DataDomain
+from datadomain.datadomain import DataDomain


### PR DESCRIPTION
The problem is that the original import failed in python 3.7 with:

~~~~
➜ python3
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datadomain
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/datadomain/__init__.py", line 1, in <module>
    from datadomain import DataDomain
ImportError: cannot import name 'DataDomain' from 'datadomain' (/usr/local/lib/python3.7/site-packages/datadomain/__init__.py)
~~~~

This is now fixed, giving:

~~~~
➜ bat /usr/local/lib/python3.7/site-packages/datadomain/__init__.py
───────┬───────────────────────────────────  
       │ File: /usr/local/lib/python3.7/site-packages/datadomain/__init__.py
───────┼───────────────────────────────────
   1   │ from datadomain.datadomain import DataDomain
───────┴───────────────────────────────────
~ via 🦀 v1.44.0
➜ python3
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datadomain
>>>
~~~~